### PR TITLE
Update content for Suggest Skills

### DIFF
--- a/docs/plan/suggested-skills.md
+++ b/docs/plan/suggested-skills.md
@@ -32,3 +32,19 @@ The Cloud Adoption Framework guides readers through the full adoption lifecycle.
   - **Manage:** Gain the skills needed to manage a cloud environment.
 
 Each of the previous learning paths shares opportunities across multiple media types to maximize knowledge acquisition.
+
+# Microsoft Learn
+
+Microsoft Learn is a new approach to learning. Readiness for the new skills and responsibilities that come with cloud adoption doesn't come easily. Microsoft Learn provides a more rewarding approach to hands-on learning that helps you achieve your goals faster. Earn points and levels, and achieve more!
+Here are a couple examples of tailored learning paths on Microsoft Learn which align to the Plan section of Cloud Adoption Framework:
+
+[Evolve your DevOps practices](learn/paths/evolve-your-devops-practices/):DevOps is the union of people, process, and products to enable continuous delivery of value to your end users. Azure DevOps is a set of services that gives you the tools you need to do just that. With Azure DevOps, you can build, test, and deploy any application, either to the cloud or on premises.
+
+[Azure for the Data Engineer](learn/paths/azure-for-the-data-engineer/):Explore how the world of data has evolved and how the advent of cloud technologies is providing new opportunities for business to explore. You will learn the various data platform technologies that are available, and how a Data Engineer can take advantage of this technology to an organization benefit.     
+
+To discover additional learning paths, browse the [Learn catalog] (/learn/browse). Use the Roles filter to align learning paths with your role.
+
+
+
+
+


### PR DESCRIPTION
Changing the Suggested Skills portion of CAF to: remove links to decommissioned sites and to align specific MS Learn learning paths to the corresponding sections of CAF. This change is done in conjunction with Brian Blanchard in an effort to provide more specific resources on supporting customers through their cloud journey.