### PR TITLE
Update with links to MS Learn learning path

### DIFF
--- a/docs/migrate/azure-migration-guide/migrate.md
+++ b/docs/migrate/azure-migration-guide/migrate.md
@@ -261,9 +261,9 @@ As you migrate into cloud technologies this presents a great opportunity to set 
 ## Suggested Skills
 
 Microsoft Learn is a new approach to learning. Readiness for the new skills responsibilities that come with cloud adoption doesn't come easily. Microsoft Learn provides a more rewarding approach to hands-on learning that helps you achieve your goals faster. Earn points and levels, and achieve more!
-Here is an examples of a tailored learning paths on Microsoft Learn which complements the Set up for DevOps guidance in the Cloud Adoption Framework
+Here is an examples of a tailored learning paths on Microsoft Learn which complements the set up for DevOps guidance in the Cloud Adoption Framework. 
 
-[Build applications with Azure DevOps](https://docs.microsoft.com/en-us/learn/paths/build-applications-with-azure-devops/):Collaborate with others to build your applications using Azure Pipelines and GitHub. Run automated tests in your pipeline to validate code quality. Scan your source code and third-party components for potential vulnerabilities. Define multiple pipelines that work together to build your application.  Build applications using both Microsoft-hosted agents and your own build agents. 
+[Build applications with Azure DevOps](https://docs.microsoft.com/learn/paths/build-applications-with-azure-devops/):Collaborate with others to build your applications using Azure Pipelines and GitHub. Run automated tests in your pipeline to validate code quality. Scan your source code and third-party components for potential vulnerabilities. Define multiple pipelines that work together to build your application. Build applications using both Microsoft-hosted agents and your own build agents. 
 
 # [Cost management](#tab/ManageCost)
 

--- a/docs/migrate/azure-migration-guide/migrate.md
+++ b/docs/migrate/azure-migration-guide/migrate.md
@@ -258,6 +258,13 @@ As you migrate into cloud technologies this presents a great opportunity to set 
 
 [Azure DevOps](https://dev.azure.com) provides all of the required functionality and integration with Azure, On-premises, or even other clouds. Find out more [here](https://azure.microsoft.com/services/devops). For a guided training, see [CI and CD with Azure DevOps - Quickstart](https://microsoft.github.io/PartsUnlimited/pandp/200.1x-PandP-CICDQuickstartwithVSTS.html).
 
+## Suggested Skills
+
+Microsoft Learn is a new approach to learning. Readiness for the new skills responsibilities that come with cloud adoption doesn't come easily. Microsoft Learn provides a more rewarding approach to hands-on learning that helps you achieve your goals faster. Earn points and levels, and achieve more!
+Here is an examples of a tailored learning paths on Microsoft Learn which complements the Set up for DevOps guidance in the Cloud Adoption Framework
+
+[Build applications with Azure DevOps](https://docs.microsoft.com/en-us/learn/paths/build-applications-with-azure-devops/):Collaborate with others to build your applications using Azure Pipelines and GitHub. Run automated tests in your pipeline to validate code quality. Scan your source code and third-party components for potential vulnerabilities. Define multiple pipelines that work together to build your application.  Build applications using both Microsoft-hosted agents and your own build agents. 
+
 # [Cost management](#tab/ManageCost)
 
 As you migrate resources to your cloud environment, it's important to perform periodic cost analysis. This helps you avoid unexpected usage charges, since the migration process can place additional usage requirements on your services. You can also resize resources as needed to balance cost and workload (discussed in more detail in the **[Optimize and Transform](./optimize-and-transform.md)** section).

--- a/docs/migrate/azure-migration-guide/migrate.md
+++ b/docs/migrate/azure-migration-guide/migrate.md
@@ -258,12 +258,13 @@ As you migrate into cloud technologies this presents a great opportunity to set 
 
 [Azure DevOps](https://dev.azure.com) provides all of the required functionality and integration with Azure, On-premises, or even other clouds. Find out more [here](https://azure.microsoft.com/services/devops). For a guided training, see [CI and CD with Azure DevOps - Quickstart](https://microsoft.github.io/PartsUnlimited/pandp/200.1x-PandP-CICDQuickstartwithVSTS.html).
 
-## Suggested Skills
+## Suggested skills
 
 Microsoft Learn is a new approach to learning. Readiness for the new skills responsibilities that come with cloud adoption doesn't come easily. Microsoft Learn provides a more rewarding approach to hands-on learning that helps you achieve your goals faster. Earn points and levels, and achieve more!
-Here is an examples of a tailored learning paths on Microsoft Learn which complements the set up for DevOps guidance in the Cloud Adoption Framework. 
 
-[Build applications with Azure DevOps](https://docs.microsoft.com/learn/paths/build-applications-with-azure-devops/):Collaborate with others to build your applications using Azure Pipelines and GitHub. Run automated tests in your pipeline to validate code quality. Scan your source code and third-party components for potential vulnerabilities. Define multiple pipelines that work together to build your application. Build applications using both Microsoft-hosted agents and your own build agents. 
+Here is an example of a tailored learning path on Microsoft Learn that complements the setup for DevOps guidance in the Cloud Adoption Framework. 
+
+[Build applications with Azure DevOps](https://docs.microsoft.com/learn/paths/build-applications-with-azure-devops/): Collaborate with others to build your applications using Azure Pipelines and GitHub. Run automated tests in your pipeline to validate code quality. Scan your source code and third-party components for potential vulnerabilities. Define multiple pipelines that work together to build your application. Build applications using both Microsoft-hosted agents and your own build agents. 
 
 # [Cost management](#tab/ManageCost)
 


### PR DESCRIPTION
Adding content links to the specific MS Learn learning path which supports the Set up for DevOps section within CAF.  This is to provide our customers with complementary training which supports this section of CAF. This is an exercise done in conjunction with Brian Blanchard.