### PR TITLE
Grammar fix - remove dangling word

### DIFF
--- a/docs/ready/expanded-scope/terraform-landing-zone.md
+++ b/docs/ready/expanded-scope/terraform-landing-zone.md
@@ -12,7 +12,7 @@ ms.subservice: ready
 
 # Use Terraform to build your landing zones
 
-Azure provides native services for deploying your landing zones. Other third-party tools can also help with this effort. One such tool that customers and partners often use deploy landing zones is Hashicorp's Terraform to. This section shows how to use a prototype landing zone to deploy fundamental logging, accounting, and security capabilities for an Azure subscription.
+Azure provides native services for deploying your landing zones. Other third-party tools can also help with this effort. One such tool that customers and partners often use deploy landing zones is Hashicorp's Terraform. This section shows how to use a prototype landing zone to deploy fundamental logging, accounting, and security capabilities for an Azure subscription.
 
 ## Purpose of the landing zone
 


### PR DESCRIPTION
Removing the word "to" at the end of a sentence.