### PR TITLE
Duplicate meta title

### DIFF
--- a/docs/migrate/about.md
+++ b/docs/migrate/about.md
@@ -1,5 +1,5 @@
 ---
-title: "Cloud migration"
+title: "About Cloud migration"
 titleSuffix: Microsoft Cloud Adoption Framework for Azure
 description: Introduction to Cloud Migration content
 author: BrianBlanchard


### PR DESCRIPTION
This page is orphaned.  Should it be redirected to https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/migrate/index?
If it is supposed to be part of the TOC, please add it, but make sure the meta title is different than /migrate/index.