### PR TITLE
Consistency guidelines for naming conventions

### DIFF
--- a/docs/ready/azure-best-practices/naming-and-tagging.md
+++ b/docs/ready/azure-best-practices/naming-and-tagging.md
@@ -73,7 +73,7 @@ The following list provides recommended Azure resource type prefixes to use when
 | ----------------------------------- | -------------------- |
 | Resource group                      | rg-                  |
 | Azure Virtual Network               | vnet-                |
-| Virtual network gateway             | vnet-gw-             |
+| Virtual network gateway             | vnetgw-              |
 | Gateway connection                  | cn-                  |
 | Subnet                              | snet-                |
 | Network security group              | nsg-                 |
@@ -87,33 +87,37 @@ The following list provides recommended Azure resource type prefixes to use when
 | Azure Kubernetes Service            | aks-                 |
 | Azure Service Bus                   | sb-                  |
 | Azure Service Bus queues            | sbq-                 |
-| Azure App Service apps              | azapp-               |
-| Azure Functions apps                | azfun-               |
-| Azure Cloud Services                | azcs-                |
+| Azure Service Bus topics            | sbt-                 |
+| Azure App Service Plans             | plan-                |
+| Azure Web Apps                      | app-                 |
+| Azure Functions                     | func-                |
+| Azure Cloud Services                | cld-                 |
+| Azure SQL Database Server           | sql-                 |
 | Azure SQL Database                  | sqldb-               |
-| Azure Cosmos DB (formerly Azure DocumentDB) | cosdb-               |
+| Azure Cosmos DB                     | cosmos-              |
 | Azure Cache for Redis               | redis-               |
 | Azure Database for MySQL            | mysql-               |
+| Azure Database for PostgreSQL       | psql-                |
 | Azure SQL Data Warehouse            | sqldw-               |
 | SQL Server Stretch Database         | sqlstrdb-            |
-| Azure Storage                       | stor                 |
+| Azure Storage                       | st                   |
 | Azure StorSimple                    | ssimp                |
 | Azure Search                        | srch-                |
-| Azure Cognitive Services            | cs-                  |
-| Azure Machine Learning workspace    | aml-                 |
+| Azure Cognitive Services            | cog-                 |
+| Azure Machine Learning workspace    | mlw-                 |
 | Azure Data Lake Storage             | dls                  |
 | Azure Data Lake Analytics           | dla                  |
 | Azure HDInsight - Spark             | hdis-                |
 | Azure HDInsight - Hadoop            | hdihd-               |
 | Azure HDInsight - R Server          | hdir-                |
 | Azure HDInsight - HBase             | hdihb-               |
-| Power BI Embedded                   | pbiemb               |
+| Power BI Embedded                   | pbi-                 |
 | Azure Stream Analytics              | asa-                 |
-| Azure Data Factory                  | df-                  |
+| Azure Data Factory                  | adf-                 |
 | Azure Event Hubs                    | evh-                 |
-| Azure IoT Hub                       | aih-                 |
-| Azure Notification Hubs             | anh-                 |
-| Azure Notification Hubs namespace   | anhns-               |
+| Azure IoT Hub                       | iot-                 |
+| Azure Notification Hubs             | ntf-                 |
+| Azure Notification Hubs namespace   | ntfns-               |
 
 ### Metadata tags
 
@@ -159,8 +163,8 @@ The following section provides examples of naming schemes for common Azure resou
 | Asset type               | Scope           | Format                                                                | Examples                                                                                              |
 |--------------------------|-----------------|-----------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
 | Azure Virtual Network          | Resource group  | vnet-\<Subscription type\>-\<Region\>-\<\#\#\#\>                      | <ul><li>vnet-shared-eastus2-001 </li><li>vnet-prod-westus-001 </li><li>vnet-client-eastus2-001</li></ul>                                  |
-| Virtual network virtual gateway     | Virtual network | vnet-gw-v-\<Subscription type\>-\<Region\>-\<\#\#\#\>                 | <ul><li>vnet-gw-v-shared-eastus2-001 </li><li>vnet-gw-v-prod-westus-001 </li><li>vnet-gw-v-client-eastus2-001</li></ul>                   |
-| Virtual network local gateway       | Virtual gateway | vnet-gw-l-\<Subscription type\>-\<Region\>-\<\#\#\#\>                 | <ul><li>vnet-gw-l-shared-eastus2-001 </li><li>vnet-gw-l-prod-westus-001 </li><li>vnet-gw-l-client-eastus2-001</li></ul>                   |
+| Virtual network virtual gateway     | Virtual network | vnetgw-v-\<Subscription type\>-\<Region\>-\<\#\#\#\>                 | <ul><li>vnet-gw-v-shared-eastus2-001 </li><li>vnet-gw-v-prod-westus-001 </li><li>vnet-gw-v-client-eastus2-001</li></ul>                   |
+| Virtual network local gateway       | Virtual gateway | vnetgw-l-\<Subscription type\>-\<Region\>-\<\#\#\#\>                 | <ul><li>vnet-gw-l-shared-eastus2-001 </li><li>vnet-gw-l-prod-westus-001 </li><li>vnet-gw-l-client-eastus2-001</li></ul>                   |
 | Site-to-site connections | Resource group  | cn-\<local gateway name\>-to-\<virtual gateway name\>                 | <ul><li>cn-l-gw-shared-eastus2-001-to-v-gw-shared-eastus2-001 </li><li>cn-l-gw-shared-eastus2-001-to-shared-westus-001</li></ul> |
 | Virtual network connections         | Resource group  | cn-\<subscription1\>\<region1\>-to-\<subscription2\>\<region2\>-      | <ul><li>cn-shared-eastus2-to-shared-westus </li><li>cn-prod-eastus2-to-prod-westus</li></ul>                                     |
 | Subnet                   | Virtual network | snet-\<subscription\>-\<subregion\>-\<\#\#\#\>                       | <ul><li>snet-shared-eastus2-001 </li><li>snet-prod-westus-001 </li><li>snet-client-eastus2-001</li></ul>                                  |
@@ -179,11 +183,11 @@ The following section provides examples of naming schemes for common Azure resou
 
 ### PaaS services
 
-| Asset type     | Scope  | Format                                                              | Examples                                                                                 |
-|----------------|--------|---------------------------------------------------------------------|------------------------------------------------------------------------------------------|
-| Azure App Service    | Global | azapp-\<App Name\>-\<Environment\>-\<\#\#\#\>.[{azurewebsites.net}] | <ul><li>azapp-navigator-prod-001.azurewebsites.net </li><li>azapp-accountlookup-dev-001.azurewebsites.net</li></ul> |
-| Azure Functions app   | Global | azfun-\<App Name\>-\<Environment\>-\<\#\#\#\>.[{azurewebsites.net}] | <ul><li>azfun-navigator-prod-001.azurewebsites.net </li><li>azfun-accountlookup-dev-001.azurewebsites.net</li></ul> |
-| Azure Cloud Services | Global | azcs-\<App Name\>-\<Environment\>-\<\#\#\#\>.[{cloudapp.net}]       | <ul><li>azcs-navigator-prod-001.azurewebsites.net </li><li>azcs-accountlookup-dev-001.azurewebsites.net</li></ul>   |
+| Asset type           | Scope  | Format                                                              | Examples                                                                                 |
+|----------------------|--------|---------------------------------------------------------------------|------------------------------------------------------------------------------------------|
+| Azure Web Apps       | Global | app-\<App Name\>-\<Environment\>-\<\#\#\#\>.[{azurewebsites.net}] | <ul><li>azapp-navigator-prod-001.azurewebsites.net </li><li>app-accountlookup-dev-001.azurewebsites.net</li></ul> |
+| Azure Functions      | Global | func-\<App Name\>-\<Environment\>-\<\#\#\#\>.[{azurewebsites.net}] | <ul><li>azfun-navigator-prod-001.azurewebsites.net </li><li>func-accountlookup-dev-001.azurewebsites.net</li></ul> |
+| Azure Cloud Services | Global | cld-\<App Name\>-\<Environment\>-\<\#\#\#\>.[{cloudapp.net}]       | <ul><li>azcs-navigator-prod-001.azurewebsites.net </li><li>cld-accountlookup-dev-001.azurewebsites.net</li></ul>   |
 
 ### Azure Service Bus
 
@@ -191,16 +195,19 @@ The following section provides examples of naming schemes for common Azure resou
 |--------------------|-------------|------------------------------------------------------------|------------------------------------|
 | Azure Service Bus        | Global      | sb-\<App Name\>-\<Environment\>.[{servicebus.windows.net}] | <ul><li>sb-navigator-prod </li><li>sb-emissions-dev</li></ul> |
 | Azure Service Bus queues | Service Bus | sbq-\<query descriptor\>                                   | <ul><li>sbq-messagequery</li></ul>                   |
+| Azure Service Bus topics | Service Bus | sbt-\<query descriptor\>                                   | <ul><li>sbt-messagequery</li></ul>                   |
 
 ### Databases
 
 | Asset type                          | Scope              | Format                                | Examples                                       |
 |-------------------------------------|--------------------|---------------------------------------|------------------------------------------------|
-| Azure SQL Database                  | Global             | sqldb-\<App Name\>-\<Environment\>    | <ul><li>sqldb-navigator-prod </li><li>sqldb-emissions-dev</li></ul>       |
-| Azure Cosmos DB (formerly DocumentDB) | Global             | cosdb-\<App Name\>-\<Environment\>    | <ul><li>cosdb-navigator-prod </li><li>cosdb-emissions-dev</li></ul>       |
+| Azure SQL Database Server           | Global             | sql-\<App Name\>-\<Environment\>      | <ul><li>sql-navigator-prod </li><li>sql-emissions-dev</li></ul>           |
+| Azure SQL Database                  | Azure SQL Database | sqldb-\<Database Name>-\<Environment\>| <ul><li>sqldb-users-prod </li><li>sqldb-users-dev</li></ul>               |
+| Azure Cosmos DB                     | Global             | cosmos-\<App Name\>-\<Environment\>   | <ul><li>cosdb-navigator-prod </li><li>cosdb-emissions-dev</li></ul>       |
 | Azure Cache for Redis               | Global             | redis-\<App Name\>-\<Environment\>    | <ul><li>redis-navigator-prod </li><li>redis-emissions-dev</li></ul>       |
 | Azure Database for MySQL            | Global             | mysql-\<App Name\>-\<Environment\>    | <ul><li>mysql-navigator-prod </li><li>mysql-emissions-dev</li></ul>       |
-| Azure SQL Data Warehouse                  | Global             | sqldw-\<App Name\>-\<Environment\>    | <ul><li>sqldw-navigator-prod </li><li>sqldw-emissions-dev</li></ul>       |
+| Azure Database for PostgreSQL       | Global             | psql-\<App Name\>-\<Environment\>     | <ul><li>psql-navigator-prod </li><li>psql-emissions-dev</li></ul>         |
+| Azure SQL Data Warehouse            | Global             | sqldw-\<App Name\>-\<Environment\>    | <ul><li>sqldw-navigator-prod </li><li>sqldw-emissions-dev</li></ul>       |
 | SQL Server Stretch Database         | Azure SQL Database | sqlstrdb-\<App Name\>-\<Environment\> | <ul><li>sqlstrdb-navigator-prod </li><li>sqlstrdb-emissions-dev</li></ul> |
 
 ### Storage
@@ -209,35 +216,35 @@ The following section provides examples of naming schemes for common Azure resou
 |-----------------------------------------|--------|-------------------------------------------------------------------------------|--------------------------------------------|
 | Azure Storage account - general use     | Global | st\<storage name\>\<\#\#\#\>                                                  | <ul><li>stnavigatordata001 </li><li>stemissionsoutput001</li></ul>    |
 | Azure Storage account - diagnostic logs | Global | stdiag\<first 2 letters of subscription name and number\>\<region\>\<\#\#\#\> | <ul><li>stdiagsh001eastus2001 </li><li>stdiagsh001westus001</li></ul> |
-| Azure StorSimple                              | Global | ssimp\<App Name\>\<Environment\>                                              | <ul><li>ssimpnavigatorprod </li><li>ssimpemissionsdev</li></ul>       |
+| Azure StorSimple                        | Global | ssimp\<App Name\>\<Environment\>                                              | <ul><li>ssimpnavigatorprod </li><li>ssimpemissionsdev</li></ul>       |
 
 ### AI + Machine Learning
 
 | Asset type                       | Scope          | Format                            | Examples                               |
 |----------------------------------|----------------|-----------------------------------|----------------------------------------|
 | Azure Search                     | Global         | srch-\<App Name\>-\<Environment\> | <ul><li>srch-navigator-prod </li><li>srch-emissions-dev</li></ul> |
-| Azure Cognitive Services               | Resource group | cs-\<App Name\>-\<Environment\>   | <ul><li>cs-navigator-prod </li><li>cs-emissions-dev</li></ul>     |
-| Azure Machine Learning workspace | Resource group | aml-\<App Name\>-\<Environment\>  | <ul><li>aml-navigator-prod </li><li>aml-emissions-dev</li></ul>   |
+| Azure Cognitive Services         | Resource group | cog-\<App Name\>-\<Environment\>   | <ul><li>cog-navigator-prod </li><li>cog-emissions-dev</li></ul>     |
+| Azure Machine Learning workspace | Resource group | mlw-\<App Name\>-\<Environment\>   | <ul><li>mlw-navigator-prod </li><li>mlw-emissions-dev</li></ul>     |
 
 ### Analytics
 
 | Asset type                | Scope  | Format                             | Examples                                 |
 |---------------------------|--------|------------------------------------|------------------------------------------|
-| Azure Data Factory        | Global | df-\<App Name\>\<Environment\>     | <ul><li>df-navigator-prod </li><li>df-emissions-dev</li></ul>       |
+| Azure Data Factory        | Global | adf-\<App Name\>\<Environment\>    | <ul><li>adf-navigator-prod </li><li>adf-emissions-dev</li></ul>     |
 | Azure Data Lake Storage   | Global | dls\<App Name\>\<Environment\>     | <ul><li>dlsnavigatorprod </li><li>dlsemissionsdev</li></ul>         |
 | Azure Data Lake Analytics | Global | dla\<App Name\>\<Environment\>     | <ul><li>dlanavigatorprod </li><li>dlaemissionsdev</li></ul>         |
-| Azure HDInsight - Spark         | Global | hdis-\<App Name\>-\<Environment\>  | <ul><li>hdis-navigator-prod </li><li>hdis-emissions-dev </li></ul>  |
-| Azure HDInsight - Hadoop        | Global | hdihd-\<App Name\>-\<Environment\> | <ul><li>hdihd-hadoop-prod </li><li>hdihd-emissions-dev</li></ul>    |
-| Azure HDInsight - R Server      | Global | hdir-\<App Name\>-\<Environment\>  | <ul><li>hdir-navigator-prod </li><li>hdir-emissions-dev</li></ul>   |
-| Azure HDInsight - HBase         | Global | hdihb-\<App Name\>-\<Environment\> | <ul><li>hdihb-navigator-prod </li><li>hdihb-emissions-dev</li></ul> |
-| Power BI Embedded         | Global | pbiemb\<App Name\>\<Environment\>  | <ul><li>pbiem-navigator-prod </li><li>pbiem-emissions-dev</li></ul> |
+| Azure HDInsight - Spark   | Global | hdis-\<App Name\>-\<Environment\>  | <ul><li>hdis-navigator-prod </li><li>hdis-emissions-dev </li></ul>  |
+| Azure HDInsight - Hadoop  | Global | hdihd-\<App Name\>-\<Environment\> | <ul><li>hdihd-hadoop-prod </li><li>hdihd-emissions-dev</li></ul>    |
+| Azure HDInsight - R Server| Global | hdir-\<App Name\>-\<Environment\>  | <ul><li>hdir-navigator-prod </li><li>hdir-emissions-dev</li></ul>   |
+| Azure HDInsight - HBase   | Global | hdihb-\<App Name\>-\<Environment\> | <ul><li>hdihb-navigator-prod </li><li>hdihb-emissions-dev</li></ul> |
+| Power BI Embedded         | Global | pbi-\<App Name\>\<Environment\>    | <ul><li>pbi-navigator-prod </li><li>pbi-emissions-dev</li></ul> |
 
-### Internet of Things (IoT)
+### Data Streams / Internet of Things (IoT)
 
 | Asset type                         | Scope          | Format                             | Examples                                 |
 |------------------------------------|----------------|------------------------------------|------------------------------------------|
-| Azure Stream Analytics on IoT Edge | Resource group | asa-\<App Name\>-\<Environment\>   | <ul><li>asa-navigator-prod </li><li>asa-emissions-dev</li></ul>     |
-| Azure IoT Hub                      | Global         | aih-\<App Name\>-\<Environment\>   | <ul><li>aih-navigator-prod </li><li>aih-emissions-dev</li></ul>     |
-| Azure Event Hubs                          | Global         | evh-\<App Name\>-\<Environment\>   | <ul><li>evh-navigator-prod </li><li>evh-emissions-dev</li></ul>     |
-| Azure Notification Hubs                   | Resource group | anh-\<App Name\>-\<Environment\>   | <ul><li>evh-navigator-prod </li><li>evh-emissions-dev</li></ul>     |
-| Azure Notification Hubs namespace         | Global         | anhns-\<App Name\>-\<Environment\> | <ul><li>anhns-navigator-prod </li><li>anhns-emissions-dev</li></ul> |
+| Azure Stream Analytics             | Resource group | asa-\<App Name\>-\<Environment\>   | <ul><li>asa-navigator-prod </li><li>asa-emissions-dev</li></ul>     |
+| Azure IoT Hub                      | Global         | iot-\<App Name\>-\<Environment\>   | <ul><li>iot-navigator-prod </li><li>iot-emissions-dev</li></ul>     |
+| Azure Event Hubs                   | Global         | evh-\<App Name\>-\<Environment\>   | <ul><li>evh-navigator-prod </li><li>evh-emissions-dev</li></ul>     |
+| Azure Notification Hubs            | Resource group | ntf-\<App Name\>-\<Environment\>   | <ul><li>ntf-navigator-prod </li><li>ntf-emissions-dev</li></ul>     |
+| Azure Notification Hubs namespace  | Global         | ntfns-\<App Name\>-\<Environment\> | <ul><li>ntfns-navigator-prod </li><li>ntfns-emissions-dev</li></ul> |


### PR DESCRIPTION
As many issues have noted, this document is quite inconsistent and missing data. I would like to propose the following guidelines for resource prefix naming and have implemented changes to update the documentation to those meet guidelines.

This PR should address the following issues:

- #42 Prefixes are inconsistent
- #39 App Service Plan is missing
- #29 Azure Databricks is missing
- #19 Service bus topics is missing
- #47 SQL Server is missing
- #13 Storage examples are inconsistent
- #33 Notifiation hub examples are wrong


## Proposed Guidelines and Changes

#### Only allow `a` (for Azure) in the prefix if it's part of the acronym used in docs/marketing/branding (e.g. AKS, ADF, ASA)

Every resource here is an Azure resource. Either everything should have an `a` in the prefix or nothing should. We should opt for nothing, unless it's part of something embraced by the PG.

*Changes:*
- `aih` -> `iot`
- `anh` -> `ntf`
- `anhns` -> `ntfns`
- `aml` -> `ml`
- `df` -> `adf`

#### Only allow `az` (for Azure) in the prefix if it's part of the acronym used in docs/marketing/branding.

As with the `a` prefix, `az` is inconsistently used and unnecessary.  As far as I can tell this is never used in a resource name.

*Changes:*
- `azapp` -> `app`
- `azfun` -> `func`
- `azcs` -> `cld`

#### Do not include hyphens inside prefixes

Prefixes represent the object type in azure.  Everything after the first hyphen should have meaning about the resource usage.

*Changes:*
- `vnet-gw` -> `vnetgw`

#### Keep storage prefixes as short as possible

Storage names are globally unique and limited to 24 characters so prefixes should be defined to allow as much space as possible for consumer use.

*Changes:*

- `stor` -> `st`

#### Prefer to keep prefixes 3-5 characters (prefer 3) 

Prefixes that are too short (e.g. `cs` for cognitive services) can be too easily confused with other services.  Prefixes that are too long (e.g. `pbiemb`) take up space and don't provide additional value.  3-5 feels to be the sweet spot for abbreviations. Commonly used long-standing abbreviations should remain the same (e.g. `rg`, `lb`, `kv`, `vm`, etc)

*Changes:*
- `pbiemb` -> `pbi`
- `cs` -> `cog`

#### Differentiate Azure SQL Database Servers from Databases

Unlike Cosmos databases (only CosmosDB _Accounts_ are shown) or databases in third party database technologies, Azure SQL Databases are shown as first-class objects in a resource group alongside the server.  They should therefore be differentiated.

- Azure SQL Database Server: `sql-`
- Azure SQL Database: `sqldb-`

#### Don't use `db` with database accounts or servers, only databases

- `cosdb` -> `cosmos`

## Resource Additions

- App Service Plan: `plan-`
- Azure Database for PostgreSQL: `psql-`