### PR TITLE
Fixed Recommended resource-type prefix for Storage

### DIFF
--- a/docs/ready/azure-best-practices/naming-and-tagging.md
+++ b/docs/ready/azure-best-practices/naming-and-tagging.md
@@ -96,7 +96,7 @@ The following list provides recommended Azure resource type prefixes to use when
 | Azure Database for MySQL            | mysql-               |
 | Azure SQL Data Warehouse            | sqldw-               |
 | SQL Server Stretch Database         | sqlstrdb-            |
-| Azure Storage                       | stor                 |
+| Azure Storage                       | st                   |
 | Azure StorSimple                    | ssimp                |
 | Azure Search                        | srch-                |
 | Azure Cognitive Services            | cs-                  |


### PR DESCRIPTION
Replaced 'stor' with 'st' so it is consistent with the example for Storage Account in the section titled 'Sample naming convention'