### PR TITLE
Duplicate title and description fixed

### DIFF
--- a/docs/ready/suggested-skills.md
+++ b/docs/ready/suggested-skills.md
@@ -1,7 +1,7 @@
 ---
 title: "Skills readiness path"
 titleSuffix: Microsoft Cloud Adoption Framework for Azure
-description: Overview of skills readiness path
+description: Overview of skills readiness path during the Ready phase of migration.
 author: BrianBlanchard
 ms.author: brblanch
 ms.date: 05/19/2019


### PR DESCRIPTION
This topic has the same title and description as /organize/suggested-skills.  Please make sure these aren't duplicate topics. They look the same to me.