### PR TITLE
Fixed broken image link for hub and spoke topology

### DIFF
--- a/docs/ready/enterprise-scale/network-topology-and-connectivity.md
+++ b/docs/ready/enterprise-scale/network-topology-and-connectivity.md
@@ -222,7 +222,7 @@ _Figure 4: A traditional Azure network topology._
 
 - For regional deployments, primarily use the hub and spoke topology, with landing zones VNets connecting with virtual network peering to a central hub VNet for cross-premises connectivity via ExpressRoute, VPN for branch connectivity, spoke-to-spoke connectivity via NVAs and UDRs, and internet-outbound protection via NVA, as depicted in the figure below.
 
-![Network topology and connectivity](./media/hub and spoke-topology.png)
+![Network topology and connectivity](./media/hub-and-spoke-topology.png)
 
 _Figure 5: Hub and spoke network topology._
 


### PR DESCRIPTION
Fixed broken image link for hub and spoke topology, link referred to a non-existing image.