### PR TITLE
Added prefix for Virtual Network Peering and UDRs

### DIFF
--- a/docs/ready/azure-best-practices/naming-and-tagging.md
+++ b/docs/ready/azure-best-practices/naming-and-tagging.md
@@ -88,6 +88,7 @@ This list recommends Azure resource type prefixes to use when you define your na
 |----------------------------------|-------------|
 | Virtual network                  | vnet-       |
 | Subnet                           | snet-       |
+| Virtual network peering          | peer-       |
 | Network interface (NIC)          | nic-        |
 | Public IP address                | pip-        |
 | Load balancer (internal)         | lbi-        |
@@ -99,6 +100,7 @@ This list recommends Azure resource type prefixes to use when you define your na
 | VPN connection                   | cn-         |
 | Application gateway              | agw-        |
 | Route table                      | route-      |
+| User defined route (UDR)         | udr-        |
 | Traffic Manager profile          | traf-       |
 
 ### Compute and Web


### PR DESCRIPTION
Added prefix for Virtual Network Peering and User Defined Routes (UDRs) that is commonly needed in defining standards for enterprise cloud landing zones. It is not referred to in the current document.