### PR TITLE
Update business-continuity-and-disaster-recovery.md

### DIFF
--- a/docs/ready/enterprise-scale/business-continuity-and-disaster-recovery.md
+++ b/docs/ready/enterprise-scale/business-continuity-and-disaster-recovery.md
@@ -32,7 +32,7 @@ Consider the following factors:
 
   - The impact of Availability Zones on update domains compared to availability sets and the percentage of workloads that can be under maintenance simultaneously.
 
-  - Support for specific virtual machine (VM) stock-keeping units with Availability Zones.
+  - Support for specific virtual machine (VM) sizes with Availability Zones.
 
   - Using Availability Zones is required if Microsoft Azure ultra disk storage is used.
 


### PR DESCRIPTION
Changed 'stock keeping unit' to 'size'.  This aligns with how VM types are generally referred to within the documentation; they are called 'sizes' not 'skus' or 'stock keeping units'