### PR TITLE
Update transition.md

### DIFF
--- a/docs/ready/enterprise-scale/transition.md
+++ b/docs/ready/enterprise-scale/transition.md
@@ -31,7 +31,7 @@ To understand which move strategy you should use, we will go through examples of
 
 ## Subscription move
 
-The common use cases for moving subscriptions are to organize subscriptions into management groups or when transferring subscriptions to a new Azure Active Directory tenant. Subscription moves for enterprise-scale focuses on moving subscriptions to management groups. Moving a subscription to a new tenant is mainly for [transferring billing ownership](/azure/cost-management-billing/manage/billing-subscription-transfer). For more guidance on how to move subscriptions across management groups in the same tenant, see [Moving management groups and subscriptions](/azure/governance/management-groups/manage#moving-management-groups-and-subscriptions).
+The common use cases for moving subscriptions are to organize subscriptions into management groups or when transferring subscriptions to a new Azure Active Directory tenant. Subscription moves for enterprise-scale focuses on moving subscriptions to management groups. Moving a subscription to a new tenant is mainly for [transferring billing ownership](/azure/cost-management-billing/manage/billing-subscription-transfer). For more guidance about how to move subscriptions across management groups in the same tenant, see [Moving management groups and subscriptions](/azure/governance/management-groups/manage#moving-management-groups-and-subscriptions).
 
 ### Azure RBAC requirements
 
@@ -61,7 +61,7 @@ The primary use cases to perform a resource move is when you want to consolidate
 
 When performing a resource move, both the source resource group and the target resource group are locked (this lock will not affect any of the resources in the resource group) during the move operation, meaning you cannot add, update, or delete resources in the resource groups. A resource move operation will not change the location of the resources.
 
-For more guidance on how to move resources across resource groups and subscriptions in the same tenant, see [Move resources to a new resource group or subscription](/azure/azure-resource-manager/management/move-resource-group-and-subscription).
+For more guidance about how to move resources across resource groups and subscriptions in the same tenant, see [Move resources to a new resource group or subscription](/azure/azure-resource-manager/management/move-resource-group-and-subscription).
 
 ### Before you move resources
 

--- a/docs/ready/enterprise-scale/transition.md
+++ b/docs/ready/enterprise-scale/transition.md
@@ -31,7 +31,7 @@ To understand which move strategy you should use, we will go through examples of
 
 ## Subscription move
 
-The common use cases for moving subscriptions are to organize subscriptions into management groups or when transferring subscriptions to a new Azure Active Directory tenant. Subscription moves for enterprise-scale focuses on moving subscriptions to management groups. Moving a subscription to a new tenant is mainly for [transferring billing ownership](/azure/cost-management-billing/manage/billing-subscription-transfer). For more guidance on how to move subscriptions across management groups in the same tenant, refer to the [Moving management groups and subscriptions](/azure/governance/management-groups/manage#moving-management-groups-and-subscriptions) article.
+The common use cases for moving subscriptions are to organize subscriptions into management groups or when transferring subscriptions to a new Azure Active Directory tenant. Subscription moves for enterprise-scale focuses on moving subscriptions to management groups. Moving a subscription to a new tenant is mainly for [transferring billing ownership](/azure/cost-management-billing/manage/billing-subscription-transfer). For more guidance on how to move subscriptions across management groups in the same tenant, see [Moving management groups and subscriptions](/azure/governance/management-groups/manage#moving-management-groups-and-subscriptions).
 
 ### Azure RBAC requirements
 
@@ -61,7 +61,7 @@ The primary use cases to perform a resource move is when you want to consolidate
 
 When performing a resource move, both the source resource group and the target resource group are locked (this lock will not affect any of the resources in the resource group) during the move operation, meaning you cannot add, update, or delete resources in the resource groups. A resource move operation will not change the location of the resources.
 
-For more guidance on how to move resources across resource groups and subscriptions in the same tenant please refer to the [Move resources to a new resource group or subscription](/azure/azure-resource-manager/management/move-resource-group-and-subscription) article.
+For more guidance on how to move resources across resource groups and subscriptions in the same tenant, see [Move resources to a new resource group or subscription](/azure/azure-resource-manager/management/move-resource-group-and-subscription).
 
 ### Before you move resources
 

--- a/docs/ready/enterprise-scale/transition.md
+++ b/docs/ready/enterprise-scale/transition.md
@@ -31,7 +31,7 @@ To understand which move strategy you should use, we will go through examples of
 
 ## Subscription move
 
-The common use cases for moving subscriptions are to organize subscriptions into management groups or when transferring subscriptions to a new Azure Active Directory tenant. Subscription moves for enterprise-scale focuses on moving subscriptions to management groups. Moving a subscription to a new tenant is mainly for [transferring billing ownership](/azure/cost-management-billing/manage/billing-subscription-transfer). For more guidance on how to move subscriptions between management groups in the same tenant please refer to this [article](/azure/governance/management-groups/manage#move-subscriptions).
+The common use cases for moving subscriptions are to organize subscriptions into management groups or when transferring subscriptions to a new Azure Active Directory tenant. Subscription moves for enterprise-scale focuses on moving subscriptions to management groups. Moving a subscription to a new tenant is mainly for [transferring billing ownership](/azure/cost-management-billing/manage/billing-subscription-transfer). For more guidance on how to move subscriptions across management groups in the same tenant, refer to the [Moving management groups and subscriptions](/azure/governance/management-groups/manage#moving-management-groups-and-subscriptions) article.
 
 ### Azure RBAC requirements
 
@@ -61,7 +61,9 @@ The primary use cases to perform a resource move is when you want to consolidate
 
 When performing a resource move, both the source resource group and the target resource group are locked (this lock will not affect any of the resources in the resource group) during the move operation, meaning you cannot add, update, or delete resources in the resource groups. A resource move operation will not change the location of the resources.
 
-For more guidance on how to move resources between resource groups and subscriptions in the same tenant please refer to this [article](/azure/azure-resource-manager/management/move-resource-group-and-subscription). In case you plan on deploying Enterprise-Scale in a new region and moving resources from the original region where they are deployed at the moment then use [Azure Resource Mover](/azure/resource-mover/overview) service for this use case.
+For more guidance on how to move resources across resource groups and subscriptions in the same tenant please refer to the [Move resources to a new resource group or subscription](/azure/azure-resource-manager/management/move-resource-group-and-subscription) article. 
+
+[Azure Resource Mover](/azure/resource-mover/overview) could be used in case you plan on deploying Enterprise-Scale in a new region and you would like to move certain resources from the original region where they are currently deployed to the new region. Please review and evaluate beforehand the [resources that can be moved across regions](/azure/resource-mover/overview#what-resources-can-i-move-across-regions) with Azure Resource Mover.
 
 ### Before you move resources
 

--- a/docs/ready/enterprise-scale/transition.md
+++ b/docs/ready/enterprise-scale/transition.md
@@ -61,9 +61,7 @@ The primary use cases to perform a resource move is when you want to consolidate
 
 When performing a resource move, both the source resource group and the target resource group are locked (this lock will not affect any of the resources in the resource group) during the move operation, meaning you cannot add, update, or delete resources in the resource groups. A resource move operation will not change the location of the resources.
 
-For more guidance on how to move resources across resource groups and subscriptions in the same tenant please refer to the [Move resources to a new resource group or subscription](/azure/azure-resource-manager/management/move-resource-group-and-subscription) article. 
-
-[Azure Resource Mover](/azure/resource-mover/overview) could be used in case you plan on deploying Enterprise-Scale in a new region and you would like to move certain resources from the original region where they are currently deployed to the new region. Please review and evaluate beforehand the [resources that can be moved across regions](/azure/resource-mover/overview#what-resources-can-i-move-across-regions) with Azure Resource Mover.
+For more guidance on how to move resources across resource groups and subscriptions in the same tenant please refer to the [Move resources to a new resource group or subscription](/azure/azure-resource-manager/management/move-resource-group-and-subscription) article.
 
 ### Before you move resources
 

--- a/docs/ready/enterprise-scale/transition.md
+++ b/docs/ready/enterprise-scale/transition.md
@@ -31,7 +31,7 @@ To understand which move strategy you should use, we will go through examples of
 
 ## Subscription move
 
-The common use cases for moving subscriptions are to organize subscriptions into management groups or when transferring subscriptions to a new Azure Active Directory tenant. Subscription moves for enterprise-scale focuses on moving subscriptions to management groups. Moving a subscription to a new tenant is mainly for [transferring billing ownership](/azure/cost-management-billing/manage/billing-subscription-transfer).
+The common use cases for moving subscriptions are to organize subscriptions into management groups or when transferring subscriptions to a new Azure Active Directory tenant. Subscription moves for enterprise-scale focuses on moving subscriptions to management groups. Moving a subscription to a new tenant is mainly for [transferring billing ownership](/azure/cost-management-billing/manage/billing-subscription-transfer). For more guidance on how to move subscriptions between management groups in the same tenant please refer to this [article](/azure/governance/management-groups/manage#move-subscriptions).
 
 ### Azure RBAC requirements
 
@@ -60,6 +60,8 @@ Once subscriptions are moved to a management group with existing Azure RBAC and 
 The primary use cases to perform a resource move is when you want to consolidate resources into the same resource group if they share the same lifecycle, or move resources to a different subscription due to cost, ownership, or Azure RBAC requirements.
 
 When performing a resource move, both the source resource group and the target resource group are locked (this lock will not affect any of the resources in the resource group) during the move operation, meaning you cannot add, update, or delete resources in the resource groups. A resource move operation will not change the location of the resources.
+
+For more guidance on how to move resources between resource groups and subscriptions in the same tenant please refer to this [article](/azure/azure-resource-manager/management/move-resource-group-and-subscription). In case you plan on deploying Enterprise-Scale in a new region and moving resources from the original region where they are deployed at the moment then use [Azure Resource Mover](/azure/resource-mover/overview) service for this use case.
 
 ### Before you move resources
 


### PR DESCRIPTION
Victor Azrate and I discussed linking this article to other relevant articles which provide guidance on moving subscriptions and resources to complete the story for our customers. Please let us know your feedback if this looks good to publish.

I have added the below to existing line#34
"For more guidance on how to move subscriptions between management groups in the same tenant please refer to this [article](/azure/governance/management-groups/manage#move-subscriptions)."

I have added the below to a new line#64
"For more guidance on how to move resources between resources groups and subscriptions in the same tenant please refer to this [article](/azure/azure-resource-manager/management/move-resource-group-and-subscription). In case you plan on deploying Enterprise-Scale in a new region and moving resources from the original region where they are deployed at the moment then use [Azure Resource Mover](/azure/resource-mover/overview) service for this use case."