### PR TITLE
Alignment to industry practices

### DIFF
--- a/docs/migrate/migration-considerations/assess/approve.md
+++ b/docs/migrate/migration-considerations/assess/approve.md
@@ -18,7 +18,7 @@ During the assess process of migration, each workload is evaluated, architected,
 
 ## Business impact and approval
 
-During migration, some things are likely to change in ways that impact the business. Although change sometimes can't be avoided, surprises as a result of undisclosed or undocumented changes should be. To maintain stakeholder support throughout the migration effort, it's important to avoid surprises. Surprising application owners or business stakeholders can slow or halt a cloud adoption effort.
+During migration, some things are likely to change in ways that impact the business. Although change sometimes can't be avoided, surprises as a result of undisclosed or undocumented changes should be. To maintain stakeholder support throughout the migration effort, it's important to avoid surprises as well as negative disruption to business or operations. Surprising application owners or business stakeholders can slow or halt a cloud adoption effort.
 
 Prior to migration, it is important to prepare the workload's business owner for any changes that could affect business processes, such as changes to:
 
@@ -26,14 +26,16 @@ Prior to migration, it is important to prepare the workload's business owner for
 - Access patterns or security requirements that impact the end user.
 - Data retention practices.
 - Core application performance.
+- Operational practice changes such as support model, change model, cost model changes.
+- Anticipated user experience changes.
+- etc.
 
 Even when a workload can be migrated with minimal to no change, there could still be a business impact. Replication processes can slow the performance of production systems. Changes to the environment in preparation for migration have the potential to cause routing or network performance limitations. There are many additional impacts that could result from replication, staging, or promotion activities.
 
-Regular approval activities can help minimize or avoid surprises as a result of change or performance-driven business impacts. The cloud adoption team should execute a change approval process at the end of the assessment process, before beginning the migration process.
+Regular approval activities can help minimize or avoid surprises as a result of change or performance-driven business impacts. The cloud adoption team should execute establish a suitable change advisory prior to the start of the migration process to ensure that change approvals required post the assessment process and beyond can occur seamlessly.
 
 ## Existing culture
-
-Your IT teams likely have existing mechanisms for managing change involving your on-premises assets. Typically these mechanisms are governed by traditional Information Technology Infrastructure Library-based (ITIL-based) change management processes. In many enterprise migrations, these processes involve a change advisory board (CAB) that's responsible for reviewing, documenting, and approving all IT-related requests for changes (RFC).
+Your IT teams likely have existing mechanisms for managing change involving your on-premises assets. Typically these mechanisms are governed by traditional Information IT Service Management (ITSM) change management processes. In many enterprise migrations, these processes typically involve a change advisory board (CAB) that's responsible for reviewing, documenting, and approving all IT-related requests for changes (RFC).
 
 The CAB generally includes experts from multiple IT and business teams, offering a variety of perspectives and detailed review for all IT-related changes. A CAB approval process is a proven way to reduce risk and minimize the business impact of changes involving stable workloads managed by IT operations.
 
@@ -41,27 +43,29 @@ The CAB generally includes experts from multiple IT and business teams, offering
 
 Organizational readiness for the approval of technical change is among the most common reasons for cloud migration failure. More projects are stalled by a series of technical approvals than any deficit in a cloud platform. Preparing the organization for technical change approval is an important requirement for migration success. The following are a few best practices to ensure that the organization is ready for technical approval.
 
-### ITIL change advisory board challenges
+### ITSM change advisory board challenges
 
 Every change management approach has its own set of controls and approval processes. Migration is a series of continuous changes that start with a high degree of ambiguity and develop additional clarity through the course of execution. As such, migration is best governed by agile-based change management approaches, with the cloud strategy team serving as a product owner.
 
-However, the scale and frequency of change during a cloud migration doesn't fit well with the nature of ITIL processes. The requirements of a CAB approval can risk the success of a migration, slowing or stopping the effort. Further, in the early stages of migration, ambiguity is high and subject matter expertise tends to be low. For the first several workload migrations or releases, the cloud adoption team is often in a learning mode. As such, it could be difficult for the team to provide the types of data needed to pass a CAB approval.
+However, the scale and frequency of change during a cloud migration doesn't fit well with the nature of change advisory boards. The requirements of a CAB approval can risk the success of a migration, slowing or stopping the effort. Further, in the early stages of migration, ambiguity is high and subject matter expertise tends to be low. For the first several workload migrations or releases, the cloud adoption team is often in a learning mode. As such, it could be difficult for the team to provide the types of data needed to pass a CAB a typical CAB approval.
 
 The following best practices can help the CAB maintain a degree of comfort during migration without become a painful blocker.
 
-### Standardize change
-
+### Standardizing and pre-approving change through standard change models
 It is tempting for a cloud adoption team to consider detailed architectural decisions for each workload being migrated to the cloud. It is equally tempting to use cloud migration as a catalyst to refactor past architectural decisions. For organizations that are migrating a few hundred VMs or a few dozen workloads, either approach can be properly managed. When migrating a datacenter consisting of 1,000 or more assets, each of these approaches is considered a high-risk antipattern that significantly reduces the likelihood of success. Modernizing, refactoring, and rearchitecting every application requires a diverse skill set and a wide variety of changes, and these tasks create dependencies on human efforts at scale. Each of these dependencies injects risk into the migration effort.
 
-The article on [digital estate rationalization](../../../digital-estate/rationalize.md) discusses the agility and time-saving impact of basic assumptions when rationalizing a digital estate. There is an additional benefit of standardized change. By choosing a default rationalization approach to govern the migration effort, the cloud advisory board or product owner can review and approve the application of one change to a long list of workloads. This reduces technical approval of each workload to those that require a significant architecture change to be cloud compatible.
+The article on [digital estate rationalization](../../../digital-estate/rationalize.md) discusses the agility and time-saving impact of basic assumptions when rationalizing a digital estate. By choosing a default (standard) rationalization approach to govern the migration effort, the cloud advisory board or product owner can review and approve the application of one change to a long list of workloads. This reduces technical approval of each workload to those that require a significant architecture change to be cloud compatible. Additionally to this, once the assessment process for the migration has been performed, there should be a clear idea of what changes will be required going forward and this initial list could be used to identify common change types or catergories of change (standard changes). The cloud adoption team should meet with the relevant change managers and approvers early in the project to agree on the categories and types of changes in the list, and then establish appropriate pre-approved standard change models that will enable changes to be made without the need of the CAB approval, provided certain criteria or prerequisites for the changes are met i.e. Changes can be preapproved for none production, or changes will require a tested backout plan, or changes need to be peer reveiwed, etc.
 
-### Clarify expectations and roles of approvers
-
-Before the first workload is assessed, the cloud strategy team should document and communicate the expectations of anyone involved in the approval of change. This simple activity can avoid costly delays when the cloud adoption team is fully engaged.
+**Improtant Note:** Organisations ITSM change processes will likely need to be re-aligned to work more effectively and more iteratively with the fast pace of change expected in the cloud (more guidance on this can be found in https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/migrate/migration-considerations/prerequisites/technical-complexity). It needs to be understood that this re-alignment does not happen overnight. The use of standard pre-approved changes will enable a lot more flexibility around the change process, but they need to be carefully managed to ensure the do not result in negative technical or business impact. If a standard change fails and has negative impact technically or operationally, then that pre-approved status should be removed and the change will need to go through a proper risk review and CAB the next time it is required. This practice will help increase confidence with change managers and approvers in the use of standard pre-approved changes.
 
 ### Seek approval early
+When possible, technical change should be detected and documented during the assessment process as mentioned above. Regardless of approval processes, the cloud adoption team should engage approvers early. The sooner that change approval can begin, the less likely an approval process is to block migration activities.
 
-When possible, technical change should be detected and documented during the assessment process. Regardless of approval processes, the cloud adoption team should engage approvers early. The sooner that change approval can begin, the less likely an approval process is to block migration activities.
+### Clarify expectations and roles of approvers
+Before the first workload is assessed, the cloud strategy team should document and communicate the expectations of anyone involved in the approval of change. This simple activity can avoid costly delays when the cloud adoption team is fully engaged.
+
+###  Establishment of a Cloud Change Authority
+If possible, a Cloud Change Authority could be established to facilitate triaging and potentially approvals of cloud changes. Having an authority focusing on the approval of cloud changes will ensure the correct subject matter expertise and context is applied to assess cloud change risk. It will also ensure that additional pressure and risk of bottlenecking at the CAB authority is minimized. Establishing this will require an agreement with change managers and approver and likely clear criteria as to what can be approved through the Cloud Change Authority, and what will need the CAB authorities approval. 
 
 ## Next steps
 


### PR DESCRIPTION
As promised please find the recommended changes to bring the article more in line with current industry practices. I changed ITIL to ITSM which is more appropriate, and I have added the concept of using standard pre-approved changes to try and minimize the use of the CAB. I also introduced the idea of a Cloud Change Authority to further facilitate change approvals outside of the CAB.