### PR TITLE
Update resource-abbreviations.md

### DIFF
--- a/docs/ready/azure-best-practices/resource-abbreviations.md
+++ b/docs/ready/azure-best-practices/resource-abbreviations.md
@@ -114,7 +114,6 @@ This list provides recommended abbreviations for various Azure resource types to
 | Azure Cache for Redis instance | `Microsoft.Cache/Redis` | `redis-` |
 | Azure SQL Database server | `Microsoft.Sql/servers` | `sql-` |
 | Azure SQL database | `Microsoft.Sql/servers/databases` | `sqldb-` |
-| Azure Synapse Analytics | `Microsoft.Synapse/workspaces` | `syn` |
 | Azure Synapse Analytics Workspaces | `Microsoft.Synapse/workspaces` | `synw` |
 | Azure Synapse Analytics SQL Dedicated Pool | `Microsoft.Synapse/workspaces/sqlPools` | `syndp` |
 | Azure Synapse Analytics Spark Pool | `Microsoft.Synapse/workspaces/sqlPools` | `synsp` |


### PR DESCRIPTION
It seems like there were duplicate prefixes for the same namespace entity:
| Azure Synapse Analytics | `Microsoft.Synapse/workspaces` | `syn` |
| Azure Synapse Analytics Workspaces | `Microsoft.Synapse/workspaces` | `synw` |

Removing the syn prefix seemed most logical? or am I missing something

I also think the synapse resources should be moved to the Analytics and IoT section thoughts?