### PR TITLE
Adding diagrams to holistically visualize App delivery

### DIFF
--- a/docs/ready/azure-best-practices/plan-for-app-delivery.md
+++ b/docs/ready/azure-best-practices/plan-for-app-delivery.md
@@ -44,4 +44,5 @@ This section explores key recommendations to deliver internal-facing and externa
 
 - Summarized ingress traffic patterns in Azure Landing Zones Plan for app delivery.
   ![appdelivery-ingress-pattern-v1](https://user-images.githubusercontent.com/38658285/150786316-9914527b-d2f8-420e-8b1e-a9dbb1150bae.png)
+[ESLZ-AppDelivery-IngressTrafficPattern.zip](https://github.com/azureflipper/cloud-adoption-framework/files/7925752/ESLZ-AppDelivery-IngressTrafficPattern.zip)
 

--- a/docs/ready/azure-best-practices/plan-for-app-delivery.md
+++ b/docs/ready/azure-best-practices/plan-for-app-delivery.md
@@ -41,3 +41,9 @@ This section explores key recommendations to deliver internal-facing and externa
 - When you're using Front Door and Application Gateway to help protect HTTP/S applications, use WAF policies in Front Door. Lock down Application Gateway to receive traffic only from Front Door.
 
 - Use Traffic Manager to deliver global applications that span protocols other than HTTP/S.
+
+- Ingress traffic patterns in Azure Landing Zones Plan for app delivery.
+  ![appdelivery-ingress-pattern](https://user-images.githubusercontent.com/38658285/150641238-83c3b45a-66b0-49f3-9cee-22beb0329400.png)
+
+- Egress traffic patterns in Azure Landing Zones Plan for app delivery.
+  ![appdelivery-egress-pattern](https://user-images.githubusercontent.com/38658285/150641239-81ce502a-4890-4177-843b-16e64db9fe97.png)

--- a/docs/ready/azure-best-practices/plan-for-app-delivery.md
+++ b/docs/ready/azure-best-practices/plan-for-app-delivery.md
@@ -42,8 +42,6 @@ This section explores key recommendations to deliver internal-facing and externa
 
 - Use Traffic Manager to deliver global applications that span protocols other than HTTP/S.
 
-- Ingress traffic patterns in Azure Landing Zones Plan for app delivery.
-  ![appdelivery-ingress-pattern](https://user-images.githubusercontent.com/38658285/150641238-83c3b45a-66b0-49f3-9cee-22beb0329400.png)
+- Summarized ingress traffic patterns in Azure Landing Zones Plan for app delivery.
+  ![appdelivery-ingress-pattern-v1](https://user-images.githubusercontent.com/38658285/150786316-9914527b-d2f8-420e-8b1e-a9dbb1150bae.png)
 
-- Egress traffic patterns in Azure Landing Zones Plan for app delivery.
-  ![appdelivery-egress-pattern](https://user-images.githubusercontent.com/38658285/150641239-81ce502a-4890-4177-843b-16e64db9fe97.png)


### PR DESCRIPTION
Often my customers are asking for a visualization which contains all of the application delivery guidelines in one or two drawings. I created two diagrams showing the recommended and considered ingress and egress traffic patterns as described in the Plan for App Delivery segment of ALZ.