### PR TITLE
Revert "change name from Enterprise scale to Azure landing zone"

### DIFF
--- a/docs/scenarios/aks/eslz-security-governance-and-compliance.md
+++ b/docs/scenarios/aks/eslz-security-governance-and-compliance.md
@@ -1,20 +1,20 @@
 ---
-title: Security and Governance for Azure Kubernetes Service (AKS)
+title: Governance disciplines for Azure Kubernetes Service (AKS)
 description: Learn more about the cloud security control lifecycle, and how to set up AKS security controls, Azure Policy, and AKS cost management.
 author: BrianBlanchard
 ms.author: brblanch
-ms.date: 02/25/2021
+ms.date: 04/30/2021
 ms.topic: conceptual
 ms.service: cloud-adoption-framework
 ms.subservice: scenario
 ms.custom: think-tank, e2e-aks
 ---
 
-# Security and Governance for AKS
+# Governance disciplines for AKS
 
 This article walks through aspects of Azure Kubernetes Service (AKS) security governance to think about before implementing any solution.
 
-Most of this content is technology-agnostic, because implementation varies among customers. The article focuses on how to implement solutions using Azure and open-source software. The decisions made when you create an Azure Landing Zone can partially predefine your governance, as described in [Azure Landing Zone security governance and compliance](../../ready/landing-zone/design-area/governance.md). It's important to understand governance principles because of the effect of the decisions made.
+Most of this content is technology-agnostic, because implementation varies among customers. The article focuses on how to implement solutions using Azure and open-source software. The decisions made when you create an enterprise-scale landing zone can partially predefine your governance, as described in [Enterprise-scale security governance and compliance](../../ready/landing-zone/design-area/governance.md). It's important to understand governance principles because of the effect of the decisions made.
 
 ## Attack surfaces
 
@@ -133,7 +133,7 @@ Restrict node access by limiting SSH access.
 
 Using the container-specific OS in AKS nodes typically reduces their attack surfaces since other services and functionalities are disabled. They also have read-only file systems and employ other cluster hardening practices by default. The Azure platform automatically applies OS security patches to Linux and Windows nodes on a nightly basis. If a Linux OS security update requires a host reboot, it won't automatically reboot. AKS provides mechanisms to reboot to apply those specific patches.
 
-Microsoft Defender for servers isn't applicable for AKS Linux and Windows nodes, since their operating system is managed by Microsoft. If there are no other virtual machines in the subscription where AKS is deployed, Microsoft Defender for servers can be safely disabled. If the environment has been deployed including the [Azure Landing Zone recommended Azure policies](https://github.com/Azure/Enterprise-Scale/blob/main/docs/ESLZ-Policies.md), an exclusion can be configured to the policy assignment in the management group that automatically enables Microsoft Defender for servers, to avoid unnecessary costs.
+Microsoft Defender for servers isn't applicable for AKS Linux and Windows nodes, since their operating system is managed by Microsoft. If there are no other virtual machines in the subscription where AKS is deployed, Microsoft Defender for servers can be safely disabled. If the environment has been deployed including the [enterprise-scale landing zone recommended Azure policies](https://github.com/Azure/Enterprise-Scale/blob/main/docs/ESLZ-Policies.md), an exclusion can be configured to the policy assignment in the management group that automatically enables Microsoft Defender for servers, to avoid unnecessary costs.
 
 ### Application security
 
@@ -178,10 +178,10 @@ AKS has several interfaces to other Azure services like Azure Active Directory, 
 
 Here are some other design considerations for AKS security governance and compliance:
 
-- If you create an AKS cluster in a subscription deployed according to Azure Landing Zone best practices, get familiar with the Azure policies that will be inherited by the clusters, as described in [Policies included in Azure Landing Zones reference implementations](https://github.com/Azure/Enterprise-Scale/blob/main/docs/ESLZ-Policies.md).
-- Decide whether the cluster's control plane should be accessible via the internet (in which case IP restrictions are recommended), which is the default, or only from within your private network in Azure or on-premises as a private cluster. Note that, as described in [Policies included in Azure Landing Zones reference implementations](https://github.com/Azure/Enterprise-Scale/blob/main/docs/ESLZ-Policies.md), if your organization is following Azure Landing Zone best practices, the `Corp` management group will have an Azure Policy associated that forces clusters to be private.
-- Evaluate using the built-in [AppArmor](/azure/aks/operator-best-practices-cluster-security#app-armor) Linux security module to limit actions that containers can perform, like read, write, execute, or system functions like mounting file systems. For example, as described in [Policies included in Azure Landing Zones reference implementations](https://github.com/Azure/Enterprise-Scale/blob/main/docs/ESLZ-Policies.md), all subscriptions will have Azure policies that prevent pods in all AKS clusters from creating privileged containers.
-- Evaluate using [`seccomp` (secure computing)](/azure/aks/operator-best-practices-cluster-security#secure-computing) at the process level to limit the process calls that containers can perform. For example, the Azure Policy applied as part of the generic Azure Landing Zone implementation in the landing zones management group to prevent container privilege escalation to root uses `seccomp` through Azure policies for Kubernetes.
+- If you create an AKS cluster in a subscription deployed according to enterprise-scale landing zone best practices, get familiar with the Azure policies that will be inherited by the clusters, as described in [Policies included in enterprise-scale landing zones reference implementations](https://github.com/Azure/Enterprise-Scale/blob/main/docs/ESLZ-Policies.md).
+- Decide whether the cluster's control plane should be accessible via the internet (in which case IP restrictions are recommended), which is the default, or only from within your private network in Azure or on-premises as a private cluster. Note that, as described in [Policies included in enterprise-scale landing zones reference implementations](https://github.com/Azure/Enterprise-Scale/blob/main/docs/ESLZ-Policies.md), if your organization is following enterprise-scale landing zone best practices, the `Corp` management group will have an Azure Policy associated that forces clusters to be private.
+- Evaluate using the built-in [AppArmor](/azure/aks/operator-best-practices-cluster-security#app-armor) Linux security module to limit actions that containers can perform, like read, write, execute, or system functions like mounting file systems. For example, as described in [Policies included in enterprise-scale landing zones reference implementations](https://github.com/Azure/Enterprise-Scale/blob/main/docs/ESLZ-Policies.md), all subscriptions will have Azure policies that prevent pods in all AKS clusters from creating privileged containers.
+- Evaluate using [`seccomp` (secure computing)](/azure/aks/operator-best-practices-cluster-security#secure-computing) at the process level to limit the process calls that containers can perform. For example, the Azure Policy applied as part of the generic enterprise-scale landing zone implementation in the landing zones management group to prevent container privilege escalation to root uses `seccomp` through Azure policies for Kubernetes.
 - Decide whether your container registry is accessible via the internet, or only within a specific virtual network. Disabling internet access in a container registry can have negative effects on other systems that rely on public connectivity to access it, such as continuous integration pipelines or Microsoft Defender for image scanning. For more information, see [Connect privately to a container registry using Azure Private Link](/azure/container-registry/container-registry-private-link).
 - Decide whether your private container registry will be shared across multiple landing zones or if you'll deploy a dedicated container registry to each landing zone subscription.
 - Consider using a security solution like [Microsoft Defender for Kubernetes](/azure/security-center/defender-for-kubernetes-introduction) for threat detection.
@@ -194,9 +194,9 @@ Here are some other design considerations for AKS security governance and compli
 - [Secure pod access to resources](/azure/aks/developer-best-practices-pod-security#secure-pod-access-to-resources). Provide the least number of permissions, and avoid using root or privileged escalation.
 - Use [pod-managed identities](/azure/aks/operator-best-practices-identity#use-pod-managed-identities) and [Azure Key Vault provider for Secrets Store CSI Driver](/azure/aks/csi-secrets-store-driver) to protect secrets, certificates, and connection strings.
 - Use [AKS node image upgrade](/azure/aks/node-image-upgrade) to update AKS cluster node images if possible, or [kured](/azure/aks/node-updates-kured) to automate node reboots after applying updates.
-- Monitor and enforce configuration by using the [Azure Policy add-on for Kubernetes](/azure/aks/use-azure-policy). In subscriptions deployed according to Azure Landing Zones best practices, this configuration will happen automatically through an Azure Policy deployed at the management group level.
+- Monitor and enforce configuration by using the [Azure Policy add-on for Kubernetes](/azure/aks/use-azure-policy). In subscriptions deployed according to enterprise-scale landing zones best practices, this configuration will happen automatically through an Azure Policy deployed at the management group level.
 - View AKS recommendations in [Microsoft Defender for Cloud](/azure/security-center/security-center-introduction).
-- Use [Microsoft Defender for Kubernetes](/azure/security-center/defender-for-kubernetes-introduction). Microsoft Defender for Kubernetes is configured automatically in AKS clusters created in subscriptions deployed according to Azure Landing Zones best practices, which include an Azure Policy to automatically onboard AKS clusters to Microsoft Defender for Cloud at the management group level.
+- Use [Microsoft Defender for Kubernetes](/azure/security-center/defender-for-kubernetes-introduction). Microsoft Defender for Kubernetes is configured automatically in AKS clusters created in subscriptions deployed according to enterprise-scale landing zones best practices, which include an Azure Policy to automatically onboard AKS clusters to Microsoft Defender for Cloud at the management group level.
 - Deploy a dedicated and private instance of [Azure Container Registry](/azure/container-registry/) to each landing zone subscription.
 - Use [Private Link for Azure Container Registry](/azure/container-registry/container-registry-private-link) to connect it to AKS.
 - Scan your images for vulnerabilities with [Microsoft Defender for container registries](/azure/security-center/defender-for-container-registries-introduction), or any other image scanning solution.


### PR DESCRIPTION
Reverts MicrosoftDocs/cloud-adoption-framework#743 - landing zone should always be lower case. We need to make this correction before merging or publishing. 