### PR TITLE
Update private-link-and-dns-integration-at-scale.md

### DIFF
--- a/docs/ready/azure-best-practices/private-link-and-dns-integration-at-scale.md
+++ b/docs/ready/azure-best-practices/private-link-and-dns-integration-at-scale.md
@@ -183,7 +183,7 @@ In addition to the private DNS zones, we also need to [create a set of custom Az
          "details": {
            "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
            "roleDefinitionIds": [
-             "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7"
+             "/providers/Microsoft.Authorization/roleDefinitions/b12aa53e-6015-4669-85d0-8515ebb3ae7f"
            ],           
            "deployment": {
              "properties": {


### PR DESCRIPTION
The document states that 'Private DNS Zone Contributor' role should be assigned to the Managed Identity of the DeployIfNotExists policy. But the role ID in the policy is 'Network Contributor'. Changed this to the role id of 'Private DNS Zone Contributor'.