### PR TITLE
Adding Container Apps Environment

### DIFF
--- a/docs/ready/azure-best-practices/resource-abbreviations.md
+++ b/docs/ready/azure-best-practices/resource-abbreviations.md
@@ -113,7 +113,7 @@ The Azure Naming Tool generates Azure-compliant names and can help you standardi
 |--|--|--|
 | AKS cluster | `Microsoft.ContainerService/managedClusters` | `aks` |
 | Container apps | `Microsoft.App/containerApps` | `ca` |
-| Container apps environment | `Microsoft.App/managedEnvironments` | `ce` |
+| Container apps environment | `Microsoft.App/managedEnvironments` | `cae` |
 | Container registry | `Microsoft.ContainerRegistry/registries` | `cr` |
 | Container instance | `Microsoft.ContainerInstance/containerGroups` | `ci` |
 | Service Fabric cluster | `Microsoft.ServiceFabric/clusters` | `sf` |

--- a/docs/ready/azure-best-practices/resource-abbreviations.md
+++ b/docs/ready/azure-best-practices/resource-abbreviations.md
@@ -112,8 +112,8 @@ The Azure Naming Tool generates Azure-compliant names and can help you standardi
 | Resource | Resource provider namespace | Abbreviation |
 |--|--|--|
 | AKS cluster | `Microsoft.ContainerService/managedClusters` | `aks` |
-| Container apps | `Microsoft.App/containerApps` | `ctap` |
-| Container apps environment | `Microsoft.App/containerApps` | `ctae` |
+| Container apps | `Microsoft.App/containerApps` | `ca` |
+| Container apps environment | `Microsoft.App/managedEnvironments` | `ce` |
 | Container registry | `Microsoft.ContainerRegistry/registries` | `cr` |
 | Container instance | `Microsoft.ContainerInstance/containerGroups` | `ci` |
 | Service Fabric cluster | `Microsoft.ServiceFabric/clusters` | `sf` |

--- a/docs/ready/azure-best-practices/resource-abbreviations.md
+++ b/docs/ready/azure-best-practices/resource-abbreviations.md
@@ -113,6 +113,7 @@ The Azure Naming Tool generates Azure-compliant names and can help you standardi
 |--|--|--|
 | AKS cluster | `Microsoft.ContainerService/managedClusters` | `aks` |
 | Container apps | `Microsoft.App/containerApps` | `ctap` |
+| Container apps environment | `Microsoft.App/containerApps` | `ctae` |
 | Container registry | `Microsoft.ContainerRegistry/registries` | `cr` |
 | Container instance | `Microsoft.ContainerInstance/containerGroups` | `ci` |
 | Service Fabric cluster | `Microsoft.ServiceFabric/clusters` | `sf` |


### PR DESCRIPTION
A Container App needs to be in a container apps environment. I tend to name them with `ctae`. What do you think?