### PR TITLE
Update contoso-migration-rds-to-wvd.md

### DIFF
--- a/docs/migrate/azure-best-practices/contoso-migration-rds-to-wvd.md
+++ b/docs/migrate/azure-best-practices/contoso-migration-rds-to-wvd.md
@@ -227,13 +227,13 @@ After Contoso imports the FSLogixMigration module, it runs the following PowerSh
 A UDP conversion:
 
 ```powershell
-Convert-RoamingProfile -ParentPath "C:\Users\" -Target "\\Server\FSLogixProfiles$" -MaxVHDSize 20 -VHDLogicalSectorSize 512
+Convert-RoamingProfile -ParentPath "C:\Users\" -Target "\\Server\FSLogixProfiles$" -VHDMaxSizeGB 20 -VHDLogicalSectorSize 512
 ```
 
 A roaming profile conversion:
 
 ```powershell
-Convert-RoamingProfile -ProfilePath "C:\Users\User1" -Target "\\Server\FSLogixProfiles$" -MaxVHDSize 20 -VHDLogicalSectorSize 512 -VHD -IncludeRobocopyDetails -LogPath C:\temp\Log.txt
+Convert-RoamingProfile -ProfilePath "C:\Users\User1" -Target "\\Server\FSLogixProfiles$" -VHDMaxSizeGB 20 -VHDLogicalSectorSize 512 -VHD -IncludeRobocopyDetails -LogPath C:\temp\Log.txt
 ```
 
 At this point, the migration has enabled using pooled resources with Windows 10 Enterprise multi-session. Contoso can begin to deploy the necessary applications to the users who will use Windows 10 Enterprise multi-session.


### PR DESCRIPTION
The option of command Convert-RoamingProfile is wrong.

Wrong : -MaxVHDSize
Correct : -VHDMaxSizeGB

The command might be sourced from the web (preview command??)
https://christiaanbrinkhoff.com/2020/02/14/youtube-how-to-migrate-from-upd-to-fslogix-profile-container-profiles-to-windows-virtual-desktop/